### PR TITLE
Downloads the tokenizer of it is not cached otherwise uses local cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.12-bookworm
 WORKDIR /app
-COPY . /app
-RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 ENTRYPOINT ["bash", "-c", "source ~/.venv/rkllm-gradio/bin/activate && exec python rkllm_server_gradio.py"]
+COPY ./requirements.txt /app/requirements.txt
+RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+COPY . /app
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-bookworm
 WORKDIR /app
 ENTRYPOINT ["bash", "-c", "source ~/.venv/rkllm-gradio/bin/activate && exec python rkllm_server_gradio.py"]
-COPY ./requirements.txt /app/requirements.txt
+COPY ./requirements.txt ./setup.sh /app/requirements.txt
 RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-bookworm
 WORKDIR /app
 ENTRYPOINT ["bash", "-c", "source ~/.venv/rkllm-gradio/bin/activate && exec python rkllm_server_gradio.py"]
 COPY ./requirements.txt ./setup.sh /app/
-RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
+RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 COPY . /app
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-bookworm
 WORKDIR /app
 ENTRYPOINT ["bash", "-c", "source ~/.venv/rkllm-gradio/bin/activate && exec python rkllm_server_gradio.py"]
-COPY ./requirements.txt ./setup.sh /app/requirements.txt
+COPY ./requirements.txt ./setup.sh /app/
 RUN pip install --upgrade pip && apt update && apt -y install cmake && bash setup.sh && bash -c "source ~/.venv/rkllm-gradio/bin/activate && python -m pip install --upgrade -r requirements.txt" && rm -rf /var/cache/apt/archives /var/lib/apt/lists/*
 COPY . /app
 

--- a/model_class.py
+++ b/model_class.py
@@ -173,7 +173,13 @@ class RKLLMLoaderClass:
                 user_prompt
             ]
         # print(prompt)
-        tokenizer = AutoTokenizer.from_pretrained(self.st_model_id, trust_remote_code=True)
+        TOKENIZER_PATH="%s/%s"%(MODEL_PATH,self.st_model_id.replace("/","-"))
+        if not os.path.exists(TOKENIZER_PATH):
+            os.mkdir(TOKENIZER_PATH)
+            tokenizer = AutoTokenizer.from_pretrained(self.st_model_id, trust_remote_code=True)
+            tokenizer.save_pretrained(TOKENIZER_PATH)
+        else
+            tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH, trust_remote_code=True)
         prompt = tokenizer.apply_chat_template(prompt, tokenize=True, add_generation_prompt=True)
         # response = {"role": "assistant", "content": "Loading..."}
         response = {"role": "assistant", "content": ""}

--- a/model_class.py
+++ b/model_class.py
@@ -175,6 +175,7 @@ class RKLLMLoaderClass:
         # print(prompt)
         TOKENIZER_PATH="%s/%s"%(MODEL_PATH,self.st_model_id.replace("/","-"))
         if not os.path.exists(TOKENIZER_PATH):
+            print("Tokenizer not cached locally, downloading to %s"%TOKENIZER_PATH)
             os.mkdir(TOKENIZER_PATH)
             tokenizer = AutoTokenizer.from_pretrained(self.st_model_id, trust_remote_code=True)
             tokenizer.save_pretrained(TOKENIZER_PATH)

--- a/model_class.py
+++ b/model_class.py
@@ -178,7 +178,7 @@ class RKLLMLoaderClass:
             os.mkdir(TOKENIZER_PATH)
             tokenizer = AutoTokenizer.from_pretrained(self.st_model_id, trust_remote_code=True)
             tokenizer.save_pretrained(TOKENIZER_PATH)
-        else
+        else:
             tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH, trust_remote_code=True)
         prompt = tokenizer.apply_chat_template(prompt, tokenize=True, add_generation_prompt=True)
         # response = {"role": "assistant", "content": "Loading..."}


### PR DESCRIPTION
Currently the RKLLM-Gradio needs to have access to huggingface. If the service is down you can not use the application even if you downloaded the model, since the tokenizer is downloaded from huggingface. This change will make the application save the tokenizer to the models folder and use it from there. This way the docer container can be run in offline mode.

